### PR TITLE
Get rid of UpdateLastMove

### DIFF
--- a/Chess/Controllers/BoardController.cs
+++ b/Chess/Controllers/BoardController.cs
@@ -269,7 +269,7 @@ namespace Chess.Controllers
                 return Json(new { fen = game.Fen, message = "Invalid move", status = "FAIL" });
             }
 
-            bool success = m_gameManager.Move(id, startLocation, endLocation);
+            bool success = m_gameManager.Move(id, startLocation, endLocation, promote);
 
             if (!success)
             {
@@ -281,11 +281,6 @@ namespace Chess.Controllers
                 }
 
                 return Json(new { fen = game.Fen, message = errorMessage, status = "FAIL" });
-            }
-
-            if (!String.IsNullOrEmpty(promote))
-            {
-                m_gameManager.PromotePiece(id, promote);
             }
 
             m_gameManager.UpdateMessage(id);

--- a/ControllerTests/BoardControllerTests.cs
+++ b/ControllerTests/BoardControllerTests.cs
@@ -362,21 +362,15 @@ namespace ControllerTests
             var fakeClockRepo = MockRepository.GenerateMock<IClockRepository>();
 
             var manager = new GameManager(fakeRepo, fakeHistoryRepo, fakeClockRepo);
-            manager.Move(c_fakeGameId, Location.H2, Location.H1);
-            manager.PromotePiece(c_fakeGameId, "Q");
+            manager.Move(c_fakeGameId, Location.H2, Location.H1, "Q");
 
             var args = fakeRepo.GetArgumentsForCallsMadeOn(a => a.AddOrUpdate(fakeGame));
-            var historyArgs = fakeHistoryRepo.GetArgumentsForCallsMadeOn(a => a.UpdateLastMove(null));
 
             fakeRepo.VerifyAllExpectations();
 
             var updatedDto = args[0][0] as GameDto;
-            var newHistoryEntry = historyArgs[0][0] as HistoryEntry;
 
             Assert.AreEqual("k6K/8/8/8/8/8/8/7q w - - 0", updatedDto.Fen, "Fen after move not as expected");
-            Assert.AreEqual("k6K/8/8/8/8/8/8/7q w - - 0", newHistoryEntry.Fen, "Fen in history is wrong");
-            Assert.AreEqual("h1=Q+", newHistoryEntry.Move, "Expected move to be h1=Q+");
-            Assert.AreEqual(c_fakeGameId, newHistoryEntry.GameId, "Expected history entry to refer to this game, " + c_fakeGameId);
         }
 
         [Test]
@@ -411,12 +405,10 @@ namespace ControllerTests
         public void MoveNumberIncrementsInHistory()
         {
             var fakeGame = GetFakeGame();
-            int moveCount = 0;
 
             var fakeRepo = MockRepository.GenerateMock<IGameRepository>();
             fakeRepo.Expect(x => x.FindById(c_fakeGameId)).Return(fakeGame);
             var fakeHistoryRepo = MockRepository.GenerateMock<IHistoryRepository>();
-            fakeHistoryRepo.Expect(x => x.LatestMoveInGame(c_fakeGameId)).WhenCalled(y => { y.ReturnValue = moveCount++; }).Return(0);
             
             var fakeClockRepo = MockRepository.GenerateMock<IClockRepository>();
 

--- a/WebEngine/Repositories/GameManager.cs
+++ b/WebEngine/Repositories/GameManager.cs
@@ -204,7 +204,7 @@ namespace RedChess.WebEngine.Repositories
                    (m_board.CurrentTurn == PieceColor.White && userName == gameDto.UserProfileWhite.UserName);
         }
 
-        public bool Move(int gameId, Location start, Location end)
+        public bool Move(int gameId, Location start, Location end, string promote = null)
         {
             var gameDto = m_repository.FindById(gameId);
             PostGameToQueueForBestMove(gameId, gameDto.MoveNumber, gameDto.Fen);
@@ -212,6 +212,11 @@ namespace RedChess.WebEngine.Repositories
 
             var success = m_board.Move(start, end);
             if (!success) return false;
+
+            if (promote != null)
+            {
+                m_board.PromotePiece(promote);
+            }
 
             gameDto.LastMove = m_board.LastMove();
             gameDto.Fen = m_board.ToFen();
@@ -239,25 +244,6 @@ namespace RedChess.WebEngine.Repositories
             }
 
             return true;
-        }
-
-        public void PromotePiece(int gameId, string typeToPromoteTo)
-        {
-            var gameDto = m_repository.FindById(gameId);
-            m_board.FromFen(gameDto.Fen);
-            m_board.PromotePiece(typeToPromoteTo);
-            gameDto.LastMove = m_board.LastMove();
-            gameDto.Fen = m_board.ToFen();
-
-            m_historyRepository.UpdateLastMove(
-                new HistoryEntry
-                {
-                    Fen = gameDto.Fen,
-                    GameId = gameDto.GameId,
-                    Move = gameDto.LastMove,
-                });
-
-            m_repository.AddOrUpdate(gameDto);
         }
 
         public void UpdateMessage(int gameId)

--- a/WebEngine/Repositories/HistoryRepository.cs
+++ b/WebEngine/Repositories/HistoryRepository.cs
@@ -42,24 +42,6 @@ namespace RedChess.WebEngine.Repositories
             }
         }
 
-        public void UpdateLastMove(HistoryEntry historyEntry)
-        {
-            using (var context = new ChessContext())
-            {
-                var entryForLastMove =
-                    context.HistoryEntries.Where(x => x.GameId == historyEntry.GameId)
-                        .OrderByDescending(x => x.MoveNumber)
-                        .Take(1)
-                        .Single();
-
-                entryForLastMove.Fen = historyEntry.Fen;
-                entryForLastMove.Move = historyEntry.Move;
-
-                context.HistoryEntries.AddOrUpdate(entryForLastMove);
-                context.SaveChanges();
-            }
-        }
-
         public void CloneGame(int newGameId, int oldGameId, int cloneUpToMove)
         {
             using (var context = new ChessContext())

--- a/WebEngine/Repositories/IGameManager.cs
+++ b/WebEngine/Repositories/IGameManager.cs
@@ -19,8 +19,7 @@ namespace RedChess.WebEngine.Repositories
         bool IsUsersTurn(int gameId, string currentUser);
         void TimeGameOut(int id, string message, string currentUser);
         void EndGameWithMessage(int id, string message, int? userIdWinner = null);
-        bool Move(int id, Location startLocation, Location endLocation);
-        void PromotePiece(int id, string promotionPiece);
+        bool Move(int id, Location startLocation, Location endLocation, string promoteTo);
         void UpdateMessage(int id);
         bool IsParticipant(string name, int gameId);
         IEnumerable<IGameBinding> WithPlayer(string userName);

--- a/WebEngine/Repositories/IHistoryRepository.cs
+++ b/WebEngine/Repositories/IHistoryRepository.cs
@@ -9,7 +9,6 @@ namespace RedChess.WebEngine.Repositories
         IEnumerable<HistoryEntry> FindAllMoves(int gameId);
         bool IsParticipant(string username, int gameId);
         void Add(HistoryEntry historyEntry);
-        void UpdateLastMove(HistoryEntry historyEntry);
         void CloneGame(int newGameId, int oldGameId, int cloneUpToMove);
     }
 }


### PR DESCRIPTION
This was a hack to modify the history once a move had been played that results in promotion. The history would temporarily contain an invalid board state (pawn on the last rank) and then be fiddled with once the user had made their promotion choice. This no longer happens.

It also avoids touching the database twice on promotion.