### PR TITLE
Offer draw

### DIFF
--- a/Chess/App_Start/BundleConfig.cs
+++ b/Chess/App_Start/BundleConfig.cs
@@ -55,7 +55,9 @@ namespace Chess
 						"~/Content/themes/base/jquery.ui.progressbar.css",
 						"~/Content/themes/base/jquery.ui.theme.css"));
 
-			BundleTable.EnableOptimizations = true;
+#if !DEBUG
+            BundleTable.EnableOptimizations = true;
+#endif
 		}
 	}
 }

--- a/Chess/Controllers/BoardController.cs
+++ b/Chess/Controllers/BoardController.cs
@@ -241,6 +241,24 @@ namespace Chess.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [VerifyIsParticipant]
+        public ActionResult AgreeDraw(int id)
+        {
+            // TODO: A mechanism to prove that the offer was really made in the first place and to
+            // TODO: persist the offer in the case that the page is refreshed
+            var game = m_gameManager.FetchGame(id);
+            m_gameManager.EndGameWithMessage(id, "Draw agreed");
+
+            var jsonObject = new { fen = game.Fen, message = "Draw agreed", status = "DRAW" };
+
+            IHubContext hubContext = GlobalHost.ConnectionManager.GetHubContext<UpdateServer>();
+            hubContext.Clients.Group(id.ToString()).addMessage(jsonObject);
+
+            return Json(jsonObject);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [VerifyIsParticipant]
         public ActionResult ClaimDraw(int id)
         {
             var game = m_gameManager.FetchGame(id);

--- a/Chess/Controllers/BoardController.cs
+++ b/Chess/Controllers/BoardController.cs
@@ -121,8 +121,20 @@ namespace Chess.Controllers
             hubContext.Clients.Group("IndexWatchers").gameListUpdate(jsonObject);
         }
 
-        //
-        // GET: /Board/Delete/5
+        [HttpPost, ActionName("OfferDraw")]
+        [ValidateAntiForgeryToken]
+        [VerifyIsParticipant]
+        public ActionResult OfferDraw(int id)
+        {
+            var game = m_gameManager.FetchGame(id);
+            var offerFrom = game.CurrentPlayerColor(m_identityProvider.CurrentUser);
+
+            var jsonObject = Json(new { DrawOfferedBy = offerFrom });
+            IHubContext hubContext = GlobalHost.ConnectionManager.GetHubContext<UpdateServer>();
+            hubContext.Clients.Group(id.ToString()).showDrawOffer(jsonObject);
+
+            return Json(new { success = true });
+        }
 
         public ActionResult Delete(int id = 0)
         {

--- a/Chess/Scripts/app/chess.js
+++ b/Chess/Scripts/app/chess.js
@@ -56,6 +56,13 @@
     }
 };
 
+Chess.prototype.showDrawOffer = function (message) {
+    if (message.DrawOfferedBy === this.currentPlayerColor) {
+        alert("You are offered a draw!");
+        $("#drawoffer").removeClass("hidden");
+    };
+};
+
 function Chess(gameId, currentPlayerColor, clock, analysisBoard) {
     this.gameId = gameId;
     this.currentPlayerColor = currentPlayerColor;
@@ -105,6 +112,10 @@ function Chess(gameId, currentPlayerColor, clock, analysisBoard) {
         this.processServerResponse(message);
     }.bind(this);
 
+    updater.client.showDrawOffer = function(message) {
+        this.showDrawOffer(message);
+    }.bind(this);
+
     // Define a callback for when the connection is established. We join the client group corresponding to our game ID.
     $.connection.hub.start(function () {
         $.connection.hub.proxies.updateserver.server.join(gameId);
@@ -120,6 +131,15 @@ function Chess(gameId, currentPlayerColor, clock, analysisBoard) {
         $("#Promote").val([]);
         return false;
     }.bind(this));
+};
+
+Chess.prototype.offerDraw = function() {
+    var gameId = this.gameId;
+
+    $.post("/Board/OfferDraw", {
+        "id": gameId,
+        "__RequestVerificationToken": $('[name=__RequestVerificationToken]').val()
+    });
 };
 
 Chess.prototype.postMove = function (start, end, promote) {

--- a/Chess/Scripts/app/chess.js
+++ b/Chess/Scripts/app/chess.js
@@ -18,7 +18,12 @@
     }
 
     if (data.mayClaimDraw) {
-        $("#drawbutton").show();
+        $("#drawbutton").text("Claim draw");
+        $("#drawbutton").off();
+        $("#drawbutton").addClass("btn-primary");
+        $("#drawbutton").click(function () {
+            this.claimDraw();
+        });
     }
 
     if (data.status == "RESIGN" || data.status == "TIME" || data.status == "DRAW") {
@@ -108,9 +113,6 @@ function Chess(gameId, currentPlayerColor, clock, analysisBoard) {
     // Hide the promotion UI and set its selection to nothing
     $("#submitmove form").hide();
     $("#Promote").val([]);
-
-    // Hide the claim the draw button
-    $("#drawbutton").hide();
 
     $("#submitmove form").submit(function () {
         this.postMove($("input#Start").val(), $("input#End").val(), $("#Promote option:selected").text());

--- a/Chess/Scripts/app/chess.js
+++ b/Chess/Scripts/app/chess.js
@@ -56,9 +56,19 @@
     }
 };
 
+Chess.prototype.respondToDrawOffer = function(accepted) {
+    if (!accepted)
+        return;
+
+    $.post("/Board/AgreeDraw", {
+        "id": this.gameId,
+        "__RequestVerificationToken": $('[name=__RequestVerificationToken]').val()
+    }).done(this.processServerResponse.bind(this));
+};
+
 Chess.prototype.showDrawOffer = function (message) {
-    if (message.DrawOfferedBy === this.currentPlayerColor) {
-        alert("You are offered a draw!");
+    // Ignore your own draw offer coming back at you. TODO: show acknowledgement that it was sent
+    if (message.DrawOfferedBy !== this.currentPlayerColor) {
         $("#drawoffer").removeClass("hidden");
     };
 };

--- a/Chess/Scripts/app/chess.js
+++ b/Chess/Scripts/app/chess.js
@@ -243,6 +243,7 @@ Chess.prototype.endGame = function() {
     $("#turnindicator").text("GAME OVER");
     $("#resignbutton").hide();
     $("#drawbutton").hide();
+    $("#drawoffer").hide();
 };
 
 Chess.prototype.updateUi = function(fen) {

--- a/Chess/Views/Board/Details.cshtml
+++ b/Chess/Views/Board/Details.cshtml
@@ -38,7 +38,8 @@
         });
 
         $("#drawbutton").click(function() {
-            theChess.claimDraw();
+            $("#drawoffer").removeClass("hidden");
+            alert("Not implemented");
         });
 
         @if (clockModel != null)
@@ -69,8 +70,16 @@
         $("#lastmove").text('@Model.LastMove');
         theChess.updateTakenPieces('@Model.Fen');
 
-        @if (Model.MayClaimDraw) {
-            <text>$('#drawbutton').show()</text>
+        @if (Model.MayClaimDraw)
+        {
+            <text>
+        $("#drawbutton").text("Claim draw");
+        $("#drawbutton").off();
+        $("#drawbutton").addClass("btn-primary");
+        $("#drawbutton").click(function() {
+            theChess.claimDraw();
+        });
+        </text>
         }
 
         @if (Model.GameOver) {
@@ -96,7 +105,7 @@
         
         <div class="btn-group" role="group">
                 <a class="btn btn-default" id="resignbutton">Resign</a>
-                <a class="btn btn-default" id="drawbutton">Claim draw</a>
+                <a class="btn btn-default" id="drawbutton">Offer draw</a>
         </div>
     </div>
 
@@ -137,6 +146,15 @@
                 <div id="lastmove"></div>
                 <div id="turnindicator"></div>
             </div>
+
+            <div id="drawoffer" class="alert alert-warning hidden">
+                <span class="glyphicon glyphicon-user" aria-hidden="true"></span><strong> Draw?</strong>&nbsp;&nbsp;
+                <div class="btn-group" role="group">
+                    <a class="btn btn-default" id="accept-draw-request">Accept</a>
+                    <a class="btn btn-default" id="reject-draw-request">Reject</a>
+                </div>
+            </div>
+
             <div class="panel panel-default">
                 <div class="panel-body">
                     <div id="blacktaken" style="font-size: 36pt;"></div>

--- a/Chess/Views/Board/Details.cshtml
+++ b/Chess/Views/Board/Details.cshtml
@@ -41,6 +41,16 @@
             theChess.offerDraw();
         });
 
+        $("#accept-draw-request").click(function() {
+            theChess.respondToDrawOffer(true);
+            $("#drawoffer").addClass("hidden");
+        });
+
+        $("#reject-draw-request").click(function() {
+            theChess.respondToDrawRequest(false);
+            $("#drawoffer").addClass("hidden");
+        });
+
         @if (clockModel != null)
         {
             <text>

--- a/Chess/Views/Board/Details.cshtml
+++ b/Chess/Views/Board/Details.cshtml
@@ -38,8 +38,7 @@
         });
 
         $("#drawbutton").click(function() {
-            $("#drawoffer").removeClass("hidden");
-            alert("Not implemented");
+            theChess.offerDraw();
         });
 
         @if (clockModel != null)


### PR DESCRIPTION
Rudimentary mechanism for players to agree a draw between themselves. Known issues:

Sending a request does nothing in the UI of the requesting player.
A rejection does not notify the other player.
A player can offer a draw at any time (which is against the rules).
The fact that an offer has been made is not persisted in the database.
No check is made that the player posting AcceptDraw is the player to whom the offer was made.