### PR TITLE
Avoid database

### DIFF
--- a/Chess/Controllers/BoardController.cs
+++ b/Chess/Controllers/BoardController.cs
@@ -166,9 +166,9 @@ namespace Chess.Controllers
             return RedirectToAction("Index");
         }
 
-        private bool IsCurrentUsersTurn(int gameId)
+        private bool IsCurrentUsersTurn(IGameBinding game)
         {
-            return m_gameManager.IsUsersTurn(gameId, m_identityProvider.CurrentUser); 
+            return m_gameManager.IsUsersTurn(game, m_identityProvider.CurrentUser); 
         }
 
         [HttpPost]
@@ -279,7 +279,7 @@ namespace Chess.Controllers
             }
 
             // This is also covered by client side validation
-            if (!IsCurrentUsersTurn(id))
+            if (!IsCurrentUsersTurn(game))
             {
                 return Json(new { fen = game.Fen, message = "It's not your turn.", status = "AUTH" });
             }

--- a/ChessCommon/ChessCommon.csproj
+++ b/ChessCommon/ChessCommon.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="ChessMove.cs" />
     <Compile Include="Enumerations\BoardEvaluationType.cs" />
+    <Compile Include="Enumerations\GameStatus.cs" />
     <Compile Include="Enumerations\Location.cs" />
     <Compile Include="Enumerations\PieceColor.cs" />
     <Compile Include="Enumerations\PieceType.cs" />

--- a/ChessCommon/Enumerations/GameStatus.cs
+++ b/ChessCommon/Enumerations/GameStatus.cs
@@ -1,0 +1,12 @@
+namespace RedChess.ChessCommon.Enumerations
+{
+    public enum GameStatus
+    {
+        None,
+        Check,
+        CheckmateWhiteWins,
+        CheckmateBlackWins,
+        Stalemate,
+        DrawInsufficientMaterial
+    }
+}

--- a/ChessCommon/ExtensionMethods.cs
+++ b/ChessCommon/ExtensionMethods.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using RedChess.ChessCommon.Enumerations;
 
 namespace RedChess.ChessCommon
@@ -15,6 +16,26 @@ namespace RedChess.ChessCommon
 
             // Test is for a specific color of piece
             return pieceType == targetPieceType;
+        }
+
+        public static string FriendlyName(this GameStatus gameStatus)
+        {
+            switch (gameStatus)
+            {
+                case GameStatus.None:
+                    return String.Empty;
+                case GameStatus.Check:
+                    return "Check";
+                case GameStatus.CheckmateWhiteWins:
+                case GameStatus.CheckmateBlackWins:
+                    return "Checkmate";
+                case GameStatus.Stalemate:
+                    return "Stalemate";
+                case GameStatus.DrawInsufficientMaterial:
+                    return "Draw - insufficient material";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(gameStatus));
+            }
         }
     }
 }

--- a/ControllerTests/BoardControllerTests.cs
+++ b/ControllerTests/BoardControllerTests.cs
@@ -632,7 +632,7 @@ namespace RedChess.ControllerTests
 
             GameDto fakeGame = new FakeGame().WithStatus(canaryValue);
             var manager = MockRepository.GenerateStub<IGameManager>();
-            manager.Expect(x => x.IsUsersTurn(FakeGame.DefaultGameId, "clive")).Return(true);
+            manager.Expect(x => x.IsUsersTurn(new GameBinding(fakeGame, manager), "clive")).Return(true);
             manager.Expect(x => x.FetchGame(FakeGame.DefaultGameId)).Return(new GameBinding(fakeGame, manager));
             manager.Expect(x => x.Move(FakeGame.DefaultGameId, Location.A1, Location.A2, "")).Return(false);
             var controller = new BoardController(manager, FakeGame.StubIdentityProviderFor(fakeGame.UserProfileWhite.UserName, fakeGame.UserProfileWhite.UserId));

--- a/ControllerTests/BoardControllerTests.cs
+++ b/ControllerTests/BoardControllerTests.cs
@@ -670,7 +670,8 @@ namespace RedChess.ControllerTests
             var args = fakeRepo.GetArgumentsForCallsMadeOn(a => a.RecordMove(Arg<int>.Is.Anything,
                 Arg<string>.Is.Anything, 
                 Arg<string>.Is.Anything, 
-                Arg<DateTime>.Is.Anything));
+                Arg<DateTime>.Is.Anything, 
+                Arg<GameStatus>.Is.Anything));
 
             fakeRepo.VerifyAllExpectations();
 
@@ -790,12 +791,14 @@ namespace RedChess.ControllerTests
             fakeRepo.Expect(x => x.RecordMove(Arg<int>.Is.Equal(FakeGame.DefaultGameId),
                 Arg<string>.Is.Equal("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq E3 0"),
                 Arg<string>.Is.Equal("e4"),
-                Arg<DateTime>.Is.Equal(firstMoveMade)));
+                Arg<DateTime>.Is.Equal(firstMoveMade), 
+                Arg<GameStatus>.Is.Anything));
 
             fakeRepo.Expect(x => x.RecordMove(Arg<int>.Is.Equal(FakeGame.DefaultGameId),
                 Arg<string>.Is.Equal("rnbqkbnr/pppppppp/8/8/8/3P4/PPP1PPPP/RNBQKBNR b KQkq - 0"),
                 Arg<string>.Is.Equal("d3"),
-                Arg<DateTime>.Is.Equal(secondMoveMade)));
+                Arg<DateTime>.Is.Equal(secondMoveMade), 
+                Arg<GameStatus>.Is.Anything));
 
             var manager = new GameManager(fakeRepo, dateTimeProvider: stubDateTimeProvider);
             // The board does not change between moves because it's a fake. Both moves are made by white.

--- a/ControllerTests/BoardControllerTests.cs
+++ b/ControllerTests/BoardControllerTests.cs
@@ -632,7 +632,7 @@ namespace RedChess.ControllerTests
 
             GameDto fakeGame = new FakeGame().WithStatus(canaryValue);
             var manager = MockRepository.GenerateStub<IGameManager>();
-            manager.Expect(x => x.IsUsersTurn(new GameBinding(fakeGame, manager), "clive")).Return(true);
+            manager.Expect(x => x.IsUsersTurn(Arg<IGameBinding>.Is.Anything, Arg<string>.Is.Equal("clive"))).Return(true);
             manager.Expect(x => x.FetchGame(FakeGame.DefaultGameId)).Return(new GameBinding(fakeGame, manager));
             manager.Expect(x => x.Move(FakeGame.DefaultGameId, Location.A1, Location.A2, "")).Return(false);
             var controller = new BoardController(manager, FakeGame.StubIdentityProviderFor(fakeGame.UserProfileWhite.UserName, fakeGame.UserProfileWhite.UserId));

--- a/Database/Stored Procedures/dbo.RecordMove.sql
+++ b/Database/Stored Procedures/dbo.RecordMove.sql
@@ -17,11 +17,13 @@ AS
     BEGIN
         SET XACT_ABORT ON;
         BEGIN TRANSACTION;
+
         UPDATE  dbo.Boards
         SET     Fen = @fen ,
                 LastMove = @lastMove ,
                 MoveNumber = MoveNumber + 1,
 				Status = @status,
+				CompletionDate = case(@gameOver) when 1 then getutcdate() else CompletionDate end,
 				GameOver = gameOver
         WHERE   GameId = @gameId;
 
@@ -60,6 +62,7 @@ AS
     END;
 
 GO
+
 
 
 

--- a/Database/Stored Procedures/dbo.RecordMove.sql
+++ b/Database/Stored Procedures/dbo.RecordMove.sql
@@ -5,11 +5,14 @@ SET ANSI_NULLS ON
 GO
 
 
+
 CREATE PROCEDURE [dbo].[RecordMove]
     @gameId INT ,
     @fen NVARCHAR(MAX) ,
     @lastMove NVARCHAR(10) ,
-    @moveReceived DATETIME
+    @moveReceived DATETIME,
+	@status NVARCHAR(32),
+	@gameOver BIT
 AS
     BEGIN
         SET XACT_ABORT ON;
@@ -17,7 +20,9 @@ AS
         UPDATE  dbo.Boards
         SET     Fen = @fen ,
                 LastMove = @lastMove ,
-                MoveNumber = MoveNumber + 1
+                MoveNumber = MoveNumber + 1,
+				Status = @status,
+				GameOver = gameOver
         WHERE   GameId = @gameId;
 
         INSERT  INTO dbo.HistoryEntries
@@ -54,8 +59,8 @@ AS
         COMMIT;
     END;
 
-
 GO
+
 
 
 GRANT EXECUTE ON  [dbo].[RecordMove] TO [chessdb]

--- a/WebEngine/Repositories/GameManager.cs
+++ b/WebEngine/Repositories/GameManager.cs
@@ -284,53 +284,33 @@ namespace RedChess.WebEngine.Repositories
             PostGameToQueueForBestMove(gameId, gameDto.MoveNumber, gameDto.Fen, LongAlgebraicMove(move));
 
             var fen = m_board.ToFen();
-            m_gameRepository.RecordMove(gameId, fen, m_board.LastMove(), now);
-            UpdateMessage(gameId, fen, gameDto.Status);
+            var status = StatusMessageForCurrentBoard();
+            m_gameRepository.RecordMove(gameId, fen, m_board.LastMove(), now, status);
+
             return true;
         }
 
-        private void UpdateMessage(int gameId, string fen, string currentStatus)
+        private GameStatus StatusMessageForCurrentBoard()
         {
-            // Not efficient to fire another request at the database but it only happens for game ending and check
-            // (and the move after check), so for most moves it doesn't matter. Ultimate aim is to do it with the
-            // minimum number of requests.
-            m_board.FromFen(fen);
-
             if (m_board.KingInCheck())
             {
-                var gameDto = m_gameRepository.FindById(gameId);
-                gameDto.Status = "Check";
                 if (m_board.IsCheckmate(true))
                 {
-                    var winner = m_board.CurrentTurn == PieceColor.White ? gameDto.UserIdBlack : gameDto.UserIdWhite;
-                    EndGameWithMessage(gameDto, "Checkmate", winner);
+                    return m_board.CurrentTurn == PieceColor.White ? GameStatus.CheckmateBlackWins : GameStatus.CheckmateWhiteWins;
                 }
-                else
-                {
-                    m_gameRepository.AddOrUpdate(gameDto);
-                }
-                return;
+
+                return GameStatus.Check;
             }
             else if (m_board.IsStalemate())
             {
-                var gameDto = m_gameRepository.FindById(gameId);
-                EndGameWithMessage(gameDto, "Stalemate");
-                return;
+                return GameStatus.Stalemate;
             }
             else if (m_board.IsDraw())
             {
-                var gameDto = m_gameRepository.FindById(gameId);
-                EndGameWithMessage(gameDto, "Insufficient material - draw");
-                return;
+                return GameStatus.DrawInsufficientMaterial;
             }
-            else
-            {
-                if (currentStatus == "") // No point setting the status if there's no change
-                    return;
-                var gameDto = m_gameRepository.FindById(gameId);
-                gameDto.Status = "";
-                m_gameRepository.AddOrUpdate(gameDto);
-            }
+
+            return GameStatus.None;
         }
 
         public void EndGameWithMessage(int gameId, string message, int? userIdWinner = null)
@@ -355,7 +335,7 @@ namespace RedChess.WebEngine.Repositories
             gameDto.Status = message;
             gameDto.CompletionDate = DateTime.UtcNow;
             gameDto.GameOver = true;
-            if(userIdWinner != null)
+            if (userIdWinner != null)
                 gameDto.UserIdWinner = userIdWinner;
             m_gameRepository.AddOrUpdate(gameDto);
         }
@@ -385,13 +365,11 @@ namespace RedChess.WebEngine.Repositories
 
             var newGame = new GameDto
             {
-                Fen = board.ToFen(),
-                UserIdBlack = currentUserId,
-                UserIdWhite = currentUserId
+                Fen = board.ToFen(), UserIdBlack = currentUserId, UserIdWhite = currentUserId
             };
 
             m_gameRepository.AddOrUpdate(newGame);
-            m_historyRepository.Add(new HistoryEntry { Fen = newGame.Fen, GameId = newGame.GameId, Move = "" });
+            m_historyRepository.Add(new HistoryEntry {Fen = newGame.Fen, GameId = newGame.GameId, Move = ""});
 
             return newGame.GameId;
         }
@@ -424,7 +402,7 @@ namespace RedChess.WebEngine.Repositories
             // Update again to force save of the clockId in the GameDto
             m_gameRepository.AddOrUpdate(newGame);
 
-            m_historyRepository.Add(new HistoryEntry { Fen = newGame.Fen, GameId = newGame.GameId, Move = ""});
+            m_historyRepository.Add(new HistoryEntry {Fen = newGame.Fen, GameId = newGame.GameId, Move = ""});
 
             return newGame.GameId;
         }

--- a/WebEngine/Repositories/GameManager.cs
+++ b/WebEngine/Repositories/GameManager.cs
@@ -277,7 +277,7 @@ namespace RedChess.WebEngine.Repositories
             }
             else
             {
-                move =new ChessMove(start, end);
+                move = new ChessMove(start, end);
             }
 
             // We post the move with the old fen and movenumber
@@ -286,6 +286,10 @@ namespace RedChess.WebEngine.Repositories
             var fen = m_board.ToFen();
             var status = StatusMessageForCurrentBoard();
             m_gameRepository.RecordMove(gameId, fen, m_board.LastMove(), now, status);
+            if (status > GameStatus.Check)
+            {
+                PostGameEndedMessage(gameId);
+            }
 
             return true;
         }

--- a/WebEngine/Repositories/GameManager.cs
+++ b/WebEngine/Repositories/GameManager.cs
@@ -246,12 +246,11 @@ namespace RedChess.WebEngine.Repositories
             return false;
         }
 
-        public bool IsUsersTurn(int gameId, string userName)
+        public bool IsUsersTurn(IGameBinding game, string userName)
         {
-            var gameDto = m_gameRepository.FindById(gameId);
-            m_board.FromFen(gameDto.Fen);
-            return (m_board.CurrentTurn == PieceColor.Black && userName == gameDto.UserProfileBlack.UserName) ||
-                   (m_board.CurrentTurn == PieceColor.White && userName == gameDto.UserProfileWhite.UserName);
+            m_board.FromFen(game.Fen);
+            return (m_board.CurrentTurn == PieceColor.Black && userName == game.UserProfileBlack.UserName) ||
+                   (m_board.CurrentTurn == PieceColor.White && userName == game.UserProfileWhite.UserName);
         }
 
         private string LongAlgebraicMove(ChessMove move)

--- a/WebEngine/Repositories/GameRepository.cs
+++ b/WebEngine/Repositories/GameRepository.cs
@@ -6,6 +6,8 @@ using System.Data.Entity.Migrations;
 using System.Linq;
 using LinqToQuerystring;
 using Microsoft.Azure;
+using RedChess.ChessCommon;
+using RedChess.ChessCommon.Enumerations;
 using RedChess.ChessCommon.Interfaces;
 using RedChess.WebEngine.Models;
 using RedChess.WebEngine.Repositories.Interfaces;
@@ -43,15 +45,17 @@ namespace RedChess.WebEngine.Repositories
             }
         }
 
-        public void RecordMove(int gameId, string fen, string lastMove, DateTime moveReceivedAt)
+        public void RecordMove(int gameId, string fen, string lastMove, DateTime moveReceivedAt, GameStatus status)
         {
             using (var context = new ChessContext())
             {
-                context.Database.ExecuteSqlCommand("EXEC dbo.RecordMove @p0, @p1, @p2, @p3", 
+                context.Database.ExecuteSqlCommand("EXEC dbo.RecordMove @p0, @p1, @p2, @p3, @p4, @p5", 
                     gameId, 
                     fen, 
                     lastMove,
-                    moveReceivedAt);
+                    moveReceivedAt,
+                    status.FriendlyName(),
+                    status > GameStatus.Check); // Game over
             }
         }
 

--- a/WebEngine/Repositories/Interfaces/IGameManager.cs
+++ b/WebEngine/Repositories/Interfaces/IGameManager.cs
@@ -18,7 +18,6 @@ namespace RedChess.WebEngine.Repositories.Interfaces
         IEnumerable<HistoryEntry> FindAllMoves(int game);
         int CloneBoard(IBoard newBoard, int opponent, string currentUser, bool playAsBlack, int oldGameId, int movesToClone);
         void Delete(int gameId);
-        bool IsUsersTurn(int gameId, string currentUser);
         void TimeGameOut(int id, string message, string currentUser);
         void EndGameWithMessage(int id, string message, int? userIdWinner = null);
         bool Move(int id, Location startLocation, Location endLocation, string promoteTo);
@@ -33,5 +32,6 @@ namespace RedChess.WebEngine.Repositories.Interfaces
         string GetEmailHashForUsername(string username);
         void UpdateEloTable();
         bool ShouldLockUi(int gameId);
+        bool IsUsersTurn(IGameBinding game, string currentUser);
     }
 }

--- a/WebEngine/Repositories/Interfaces/IGameRepository.cs
+++ b/WebEngine/Repositories/Interfaces/IGameRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using RedChess.ChessCommon.Enumerations;
 using RedChess.ChessCommon.Interfaces;
 
 namespace RedChess.WebEngine.Repositories.Interfaces
@@ -12,6 +13,6 @@ namespace RedChess.WebEngine.Repositories.Interfaces
         void AddAnalysis(int id, int moveNumber, IProcessedAnalysis boardAnalysis);
         string Fen(int gameId);
         object FindWhere(string queryString);
-        void RecordMove(int gameId, string fen, string lastMove, DateTime moveReceivedAt);
+        void RecordMove(int gameId, string fen, string lastMove, DateTime moveReceivedAt, GameStatus status);
     }
 }

--- a/WebEngine/WebEngine.csproj
+++ b/WebEngine/WebEngine.csproj
@@ -69,7 +69,7 @@
       <HintPath>..\packages\WindowsAzure.Storage.6.1.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
-	<Reference Include="Redchess.LinqToQueryString">
+    <Reference Include="Redchess.LinqToQueryString">
       <HintPath>..\packages\Redchess.LinqToQueryString\RedChess.LinqToQueryString.dll</HintPath>
       <Private>True</Private>
     </Reference>


### PR DESCRIPTION
In the general run of play, recording a move should only access the db once to get the current status, and again to update it. 